### PR TITLE
Avoid ugly dbus message. Add escaping characters.

### DIFF
--- a/spotify-now
+++ b/spotify-now
@@ -110,7 +110,6 @@ fi
 
 # check if spotify is running
 status=`pidof spotify | wc -l`
-playback=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'PlaybackStatus' | grep -o Paused`
 if [[ $status != 1 ]]; then
     if [[ "$ERROR" == "" ]]; then
         # default error message
@@ -119,21 +118,24 @@ if [[ $status != 1 ]]; then
         echo "$ERROR"
     fi
     exit 0
-elif [[ $playback == "Paused" ]]; then
-    if [[ "$PAUSED" == "" ]]; then
-        # default paused message
-        echo ""
-    else
-        echo "$PAUSED"
-    fi
-    exit 0
-elif [[ "${1}" == "-i" || "${3}" == "-i" || "${5}" == "-i" ]]; then
-    # get mpris2 dbus status of spotify player
-    META=`dbus-send --print-reply --session --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'`
-    INFO="${INFO//"%album"/$(album)}"
-    INFO="${INFO//"%artist"/$(artist)}"
-    INFO="${INFO//"%disc"/$(disc)}"
-    INFO="${INFO//"%title"/$(title)}"
-    INFO="${INFO//"%track"/$(track)}"
-    echo $INFO
+else
+	playback=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'PlaybackStatus' | grep -o Paused`
+	if [[ $playback == "Paused" ]]; then
+		if [[ "$PAUSED" == "" ]]; then
+			# default paused message
+			echo ""
+		else
+			echo "$PAUSED"
+		fi
+		exit 0
+	elif [[ "${1}" == "-i" || "${3}" == "-i" || "${5}" == "-i" ]]; then
+   		# get mpris2 dbus status of spotify player
+   		META=`dbus-send --print-reply --session --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'`
+   		INFO="${INFO//"%album"/$(album)}"
+   		INFO="${INFO//"%artist"/$(artist)}"
+   		INFO="${INFO//"%disc"/$(disc)}"
+   		INFO="${INFO//"%title"/$(title)}"
+   		INFO="${INFO//"%track"/$(track)}"
+   		echo $INFO
+	fi
 fi

--- a/spotify-now
+++ b/spotify-now
@@ -85,12 +85,15 @@ fi
 INFO=""
 PAUSED=""
 ERROR=""
+ESCAPE=false
 if [[ "${1}" == "-i" ]]; then
     INFO="${2}"
 elif [[ "${1}" == "-p" ]]; then
     PAUSED="${2}"
 elif [[ "${1}" == "-e" ]]; then
     ERROR="${2}"
+elif [[ "${1}" == "-escape" ]]; then
+	ESCAPE=true
 fi
 if [[ "${3}" == "-i" ]]; then
     INFO="${4}"
@@ -98,6 +101,8 @@ elif [[ "${3}" == "-p" ]]; then
     PAUSED="${4}"
 elif [[ "${3}" == "-e" ]]; then
     ERROR="${4}"
+elif [[ "${3}" == "-escape" ]]; then
+	ESCAPE=true
 fi
 if [[ "${5}" == "-i" ]]; then
     INFO="${6}"
@@ -105,8 +110,18 @@ elif [[ "${5}" == "-p" ]]; then
     PAUSED="${6}"
 elif [[ "${5}" == "-e" ]]; then
     ERROR="${6}"
+elif [[ "${5}" == "-escape" ]]; then
+	ESCAPE=true
 fi
-
+if [[ "${7}" == "-i" ]]; then
+    INFO="${8}"
+elif [[ "${7}" == "-p" ]]; then
+    PAUSED="${8}"
+elif [[ "${7}" == "-e" ]]; then
+    ERROR="${8}"
+elif [[ "${7}" == "-escape" ]]; then
+	ESCAPE=true
+fi
 
 # check if spotify is running
 status=`pidof spotify | wc -l`
@@ -136,6 +151,12 @@ else
    		INFO="${INFO//"%disc"/$(disc)}"
    		INFO="${INFO//"%title"/$(title)}"
    		INFO="${INFO//"%track"/$(track)}"
-   		echo $INFO
+		if [ "$ESCAPE" = true ]; then
+			INFO="${INFO//&/&amp;}"
+			INFO="${INFO//</&lt;}"
+			INFO="${INFO//\"/\\\"}"
+			INFO="${INFO//\\/\\\\}"
+		fi
+		echo $INFO
 	fi
 fi


### PR DESCRIPTION
When Spotify was turned off, probing it's playback status with `dbus-send` resulted in an error message. I fixed that.
Also, I added an option to escape `& < \\` and double quotes. I use this script with i3bar, and i3bar uses Pango markup. Pango requires those characters to be escaped, otherwise nothing is shown in the bar.

Adding `-escape` option kind of messed up input parameters, I'm afraid. I suppose that more maintainable solution would be to read input parameters as one whole string and search for `-i`, `-e` and `-p`. Although I don't know just how painful that would be to implement in Shell. 
