### PR TITLE
Fix artist detection (albumArtist => artist)

### DIFF
--- a/spotify-now
+++ b/spotify-now
@@ -10,7 +10,7 @@ album () {
     echo "$res"
 }
 artist () {
-    res=$(echo "$META" | grep -m 1 "xesam:albumArtist" -b2 | tail -n1)
+    res=$(echo "$META" | grep -m 1 "xesam:artist" -b2 | tail -n1)
     res="${res%\"*}"
     res="${res#*\"}"
     # if advertisement is playing


### PR DESCRIPTION
It seems Spotify changed their XML , e.g:

$ dbus-send --print-reply --session --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'
method return sender=:1.1221 -> dest=:1.1248 reply_serial=2
   variant       array [
         ...
         dict entry(
            string "xesam:artist"
            variant                array [
                  string "Kat Krazy"
               ]
         )
         ...
